### PR TITLE
Do no add embed_url elements

### DIFF
--- a/src/Controllers/Bts_Rest_Controller.php
+++ b/src/Controllers/Bts_Rest_Controller.php
@@ -586,7 +586,7 @@ class Bts_Rest_Controller extends WP_REST_Controller
             }
         } else {
             // do not add "hard coded" types to the translations #BTS-57
-            if (in_array($field['type'], ['select', 'true_false', 'radio', 'checkbox', 'user'])) {
+            if (in_array($field['type'], ['select', 'true_false', 'radio', 'checkbox', 'user', 'embed_url'])) {
                 return;
             }
 


### PR DESCRIPTION
The data in the embed_url elements break xliff -> udf conversion.
The translators do not need these anyways, so let's remove
them for now.

BTS-66