### PR TITLE
Remove fields with names code and embed_urls

### DIFF
--- a/src/Controllers/Bts_Rest_Controller.php
+++ b/src/Controllers/Bts_Rest_Controller.php
@@ -589,6 +589,10 @@ class Bts_Rest_Controller extends WP_REST_Controller
             if (in_array($field['type'], ['select', 'true_false', 'radio', 'checkbox', 'user', 'embed_url', 'code'])) {
                 return;
             }
+            // also skipping (text) fields with the following names, as they can contain "bad" content, such as iframe code.
+            if (in_array($field['name'], ['embed_url', 'code'])) {
+                return;
+            }
 
             // checking if the field is a subfield.
             $isSubField = ($parentKey !== null ? 1 : 0);


### PR DESCRIPTION
Seems it's not only widget types, but also fields with the
same names.