### PR TITLE
Add meta: internal_comment to translations

### DIFF
--- a/bonnier-willow-bts.php
+++ b/bonnier-willow-bts.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Bonnier Willow BTS
  * Description: Plugin to add translations to a Willow site, using the BTS service.
- * Version: 0.2.17
+ * Version: 0.2.18
  * Author: Bonnier Publications
  * Author URI: https://bonnierpublications.com
  */


### PR DESCRIPTION
We need to be able to send the internal_comment field to
the translators.
The field is a postmeta field, so we need to handle this
separately, just like we do with post title and post slug.

Bumped version to 0.2.18